### PR TITLE
Add JSON export via IDC functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 sdk/
 
 # Build artifacts
+build/
 release/
 *.so
 *.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.20)
+project(VTableExplorer LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(IDASDK_DIR "" CACHE PATH "Path to IDA SDK root (containing include/ and lib/)")
+
+if(NOT IDASDK_DIR)
+    message(FATAL_ERROR "IDASDK_DIR must be set. Example: -DIDASDK_DIR=C:/idasdk")
+endif()
+
+if(NOT EXISTS "${IDASDK_DIR}/include/ida.hpp")
+    message(FATAL_ERROR "IDASDK_DIR does not point to a valid IDA SDK: ${IDASDK_DIR}")
+endif()
+
+add_library(vtable64 SHARED src/main.cpp)
+
+target_include_directories(vtable64 PRIVATE "${IDASDK_DIR}/include")
+
+target_compile_definitions(vtable64 PRIVATE
+    __NT__
+    __EA64__
+    __X64__
+)
+
+if(MSVC)
+    target_compile_options(vtable64 PRIVATE /EHsc /W3)
+endif()
+
+target_link_libraries(vtable64 PRIVATE "${IDASDK_DIR}/lib/x64_win_vc_64/ida.lib")
+
+set_target_properties(vtable64 PROPERTIES
+    OUTPUT_NAME "vtable64"
+    SUFFIX ".dll"
+    PREFIX ""
+)

--- a/scripts/test_json_export.py
+++ b/scripts/test_json_export.py
@@ -1,0 +1,190 @@
+"""Test script for VTableExplorer JSON export IDC functions.
+
+Run in IDA's IDAPython console (File > Script file...) or paste into the console.
+Requires vtable64.dll plugin to be loaded.
+"""
+import idc
+import json
+import traceback
+
+def test_scan():
+    print("\n=== Test: VTableExplorer_Scan() ===")
+    raw = idc.eval_idc("VTableExplorer_Scan()")
+    if raw == 0 or raw is None:
+        print("FAIL: eval_idc returned None/0 - is the plugin loaded?")
+        return None
+    vtables = json.loads(raw)
+    print(f"OK: Found {len(vtables)} vtables")
+    for vt in vtables[:5]:
+        print(f"  {vt['class_name']} @ {vt['address']} "
+              f"({vt['func_count']} funcs, {vt['pure_virtual_count']} pure)")
+    if len(vtables) > 5:
+        print(f"  ... and {len(vtables) - 5} more")
+
+    # Validate schema on first entry
+    if vtables:
+        expected_keys = {
+            "address", "class_name", "display_name", "func_count",
+            "pure_virtual_count", "is_abstract", "base_classes",
+            "derived_classes", "derived_count", "has_multiple_inheritance",
+            "has_virtual_inheritance", "is_intermediate", "is_windows"
+        }
+        actual_keys = set(vtables[0].keys())
+        missing = expected_keys - actual_keys
+        extra = actual_keys - expected_keys
+        if missing:
+            print(f"  WARN: missing keys: {missing}")
+        if extra:
+            print(f"  INFO: extra keys: {extra}")
+        if not missing:
+            print(f"  Schema OK: all {len(expected_keys)} expected keys present")
+    return vtables
+
+
+def test_entries(vtables):
+    print("\n=== Test: VTableExplorer_Entries(addr) ===")
+    # Pick a non-intermediate vtable with functions
+    target = None
+    for vt in vtables:
+        if not vt["is_intermediate"] and vt["func_count"] > 0:
+            target = vt
+            break
+    if not target:
+        print("SKIP: no suitable vtable found")
+        return
+
+    addr = target["address"]
+    raw = idc.eval_idc(f"VTableExplorer_Entries({addr})")
+    result = json.loads(raw)
+
+    if "error" in result:
+        print(f"FAIL: {result['error']}")
+        return
+
+    entries = result["entries"]
+    print(f"OK: {target['class_name']} @ {addr} -> {len(entries)} entries")
+    for e in entries[:5]:
+        pv = " [pure]" if e["is_pure_virtual"] else ""
+        print(f"  [{e['index']}] {e['func_name'] or '(unnamed)'} @ {e['func_addr']}{pv}")
+    if len(entries) > 5:
+        print(f"  ... and {len(entries) - 5} more")
+    return target
+
+
+def test_compare(vtables):
+    print("\n=== Test: VTableExplorer_Compare(derived, base) ===")
+    # Find a vtable with a base class that also has a vtable
+    derived = None
+    base_addr = None
+    for vt in vtables:
+        if vt["is_intermediate"] or not vt["base_classes"]:
+            continue
+        base_name = vt["base_classes"][0]
+        for other in vtables:
+            if other["class_name"] == base_name and not other["is_intermediate"]:
+                derived = vt
+                base_addr = other["address"]
+                break
+        if derived:
+            break
+    if not derived:
+        print("SKIP: no derived/base pair found")
+        return
+
+    raw = idc.eval_idc(
+        f"VTableExplorer_Compare({derived['address']},{base_addr})"
+    )
+    result = json.loads(raw)
+    print(f"OK: {result['derived_class']} vs {result['base_class']}")
+    print(f"  Inherited: {result['inherited_count']}, "
+          f"Overridden: {result['overridden_count']}, "
+          f"New: {result['new_virtual_count']}")
+    for e in result["entries"][:3]:
+        print(f"  [{e['index']}] {e['status']}: {e['derived_func_name'] or '?'}")
+    if len(result["entries"]) > 3:
+        print(f"  ... and {len(result['entries']) - 3} more")
+
+
+def test_hierarchy(vtables):
+    print("\n=== Test: VTableExplorer_Hierarchy(class_name) ===")
+    # Pick a class that has both ancestors and descendants if possible
+    target = None
+    for vt in vtables:
+        if vt["base_classes"] and vt["derived_classes"]:
+            target = vt
+            break
+    if not target:
+        # Fall back to any class with base classes
+        for vt in vtables:
+            if vt["base_classes"]:
+                target = vt
+                break
+    if not target and vtables:
+        target = vtables[0]
+    if not target:
+        print("SKIP: no vtables")
+        return
+
+    name = target["class_name"]
+    raw = idc.eval_idc(f'VTableExplorer_Hierarchy("{name}")')
+    result = json.loads(raw)
+
+    if "error" in result:
+        print(f"FAIL: {result['error']}")
+        return
+
+    print(f"OK: {result['class_name']} @ {result['address']}")
+    print(f"  Ancestors:   {result['ancestors']}")
+    print(f"  Descendants: {result['descendants']}")
+    print(f"  Funcs: {result['func_count']}, Abstract: {result['is_abstract']}")
+
+
+def test_error_handling():
+    print("\n=== Test: Error handling ===")
+    # Entries for nonexistent address
+    raw = idc.eval_idc("VTableExplorer_Entries(0xDEADBEEF)")
+    result = json.loads(raw)
+    if "error" in result:
+        print(f"OK: bad address -> {result['error']}")
+    else:
+        print(f"WARN: no error for bad address (got {len(result.get('entries', []))} entries)")
+
+    # Hierarchy for nonexistent class
+    raw = idc.eval_idc('VTableExplorer_Hierarchy("NonExistentClass12345")')
+    result = json.loads(raw)
+    if "error" in result:
+        print(f"OK: bad class -> {result['error']}")
+    else:
+        print(f"WARN: no error for bad class name")
+
+
+def main():
+    print("=" * 60)
+    print("VTableExplorer JSON Export - Test Suite")
+    print("=" * 60)
+
+    try:
+        vtables = test_scan()
+        if vtables is None:
+            print("\nABORT: Scan failed, cannot continue")
+            return
+
+        if vtables:
+            test_entries(vtables)
+            test_compare(vtables)
+            test_hierarchy(vtables)
+        else:
+            print("\nNo vtables found in this binary (expected for non-C++ binaries)")
+
+        test_error_handling()
+
+        print("\n" + "=" * 60)
+        print("All tests completed!")
+        print("=" * 60)
+    except Exception as e:
+        print(f"\nERROR: {e}")
+        traceback.print_exc()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/vtable_explorer.py
+++ b/scripts/vtable_explorer.py
@@ -1,0 +1,52 @@
+"""IDAPython wrapper for VTableExplorer JSON API.
+
+Requires the VTableExplorer plugin (vtable64.dll) to be loaded.
+
+Usage:
+    from vtable_explorer import scan, entries, compare, hierarchy
+
+    # List all vtables
+    for vt in scan():
+        print(f"{vt['class_name']} @ {vt['address']} ({vt['func_count']} funcs)")
+
+    # Get entries for a specific vtable
+    result = entries(0x140012340)
+    for e in result['entries']:
+        print(f"  [{e['index']}] {e['func_name']}")
+
+    # Compare derived vs base
+    cmp = compare(derived_addr, base_addr)
+    for e in cmp['entries']:
+        print(f"  [{e['index']}] {e['status']}: {e['derived_func_name']}")
+
+    # Get class hierarchy
+    h = hierarchy("CBaseEntity")
+    print(f"Ancestors: {h['ancestors']}")
+    print(f"Descendants: {h['descendants']}")
+"""
+import idc
+import json
+
+
+def scan():
+    """Scan and return all vtables as a list of dicts."""
+    return json.loads(idc.eval_idc("VTableExplorer_Scan()"))
+
+
+def entries(addr):
+    """Return vtable entries for the given vtable address."""
+    return json.loads(idc.eval_idc(f"VTableExplorer_Entries({addr:#x})"))
+
+
+def compare(derived_addr, base_addr):
+    """Compare derived and base vtables."""
+    return json.loads(
+        idc.eval_idc(f"VTableExplorer_Compare({derived_addr:#x},{base_addr:#x})")
+    )
+
+
+def hierarchy(class_name):
+    """Return hierarchy info for a class by name."""
+    return json.loads(
+        idc.eval_idc(f'VTableExplorer_Hierarchy("{class_name}")')
+    )

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <loader.hpp>
 #include <kernwin.hpp>
 #include "vtable_chooser.h"
+#include "vtable_idc.h"
 
 #define PLUGIN_VERSION "1.2.3"
 #define PLUGIN_DESCRIPTION "VTable Explorer v" PLUGIN_VERSION " - Graph-based inheritance view & high quality vtable analysis"
@@ -161,6 +162,7 @@ struct vtable_plugin_ctx_t : public plugmod_t {
     }
 
     virtual ~vtable_plugin_ctx_t() {
+        vtable_idc::unregister_vtable_idc_functions();
         unregister_action("vtable:explorer");
         unregister_action("vtable:tree");
         unregister_action("vtable:compare");
@@ -267,6 +269,8 @@ plugmod_t* idaapi init() {
     register_action(desc_comptoggle);
 
     hook_event_listener(HT_UI, &ui_listener, nullptr, 0);
+
+    vtable_idc::register_vtable_idc_functions();
 
     return new vtable_plugin_ctx_t;
 }

--- a/src/vtable_idc.h
+++ b/src/vtable_idc.h
@@ -1,0 +1,109 @@
+#pragma once
+#include <ida.hpp>
+#include <expr.hpp>
+#include "vtable_chooser.h"
+#include "vtable_json.h"
+
+// IDC functions exposing VTableExplorer data as JSON strings.
+// Call from IDAPython: idc.eval_idc('VTableExplorer_Scan()')
+
+namespace vtable_idc {
+
+// Ensure the global cache is populated
+static void ensure_cache() {
+    if (!g_vtable_cache.valid)
+        g_vtable_cache.refresh();
+}
+
+// --- IDC function implementations ---
+
+static error_t idaapi idc_scan(idc_value_t * /*argv*/, idc_value_t *res) {
+    ensure_cache();
+    std::string json = vtable_json::vtables_to_json(g_vtable_cache.vtables);
+    res->_set_string(qstring(json.c_str()));
+    return eOk;
+}
+
+static error_t idaapi idc_entries(idc_value_t *argv, idc_value_t *res) {
+    ensure_cache();
+    ea_t addr = (ea_t)argv[0].num;
+
+    // Find the vtable info
+    const VTableInfo *vt = nullptr;
+    for (const auto &v : g_vtable_cache.vtables) {
+        if (v.address == addr) { vt = &v; break; }
+    }
+    if (!vt) {
+        res->_set_string(qstring("{\"error\":\"vtable not found\"}"));
+        return eOk;
+    }
+
+    ea_t browse_addr = vt->is_intermediate ? vt->parent_vtable_addr : vt->address;
+    if (browse_addr == BADADDR) {
+        res->_set_string(qstring("{\"error\":\"no vtable address\"}"));
+        return eOk;
+    }
+
+    auto entries = smart_annotator::get_vtable_entries(
+        browse_addr, vt->is_windows, g_vtable_cache.sorted_addrs);
+    std::string json = vtable_json::vtable_entries_to_json(
+        browse_addr, vt->class_name, entries);
+    res->_set_string(qstring(json.c_str()));
+    return eOk;
+}
+
+static error_t idaapi idc_compare(idc_value_t *argv, idc_value_t *res) {
+    ensure_cache();
+    ea_t derived_addr = (ea_t)argv[0].num;
+    ea_t base_addr    = (ea_t)argv[1].num;
+
+    // Resolve class names
+    std::string derived_name, base_name;
+    bool is_windows = false;
+    for (const auto &v : g_vtable_cache.vtables) {
+        if (v.address == derived_addr) { derived_name = v.class_name; is_windows = v.is_windows; }
+        if (v.address == base_addr)    { base_name = v.class_name; }
+    }
+
+    auto cmp = vtable_comparison::compare_vtables(
+        derived_addr, base_addr, is_windows,
+        g_vtable_cache.sorted_addrs, derived_name, base_name);
+    std::string json = vtable_json::vtable_comparison_to_json(cmp);
+    res->_set_string(qstring(json.c_str()));
+    return eOk;
+}
+
+static error_t idaapi idc_hierarchy(idc_value_t *argv, idc_value_t *res) {
+    ensure_cache();
+    std::string class_name(argv[0].c_str());
+    std::string json = vtable_json::vtable_hierarchy_to_json(
+        class_name, g_vtable_cache.vtables);
+    res->_set_string(qstring(json.c_str()));
+    return eOk;
+}
+
+// --- Registration ---
+
+static const char idc_scan_args[]      = { 0 };
+static const char idc_entries_args[]   = { VT_LONG, 0 };
+static const char idc_compare_args[]   = { VT_LONG, VT_LONG, 0 };
+static const char idc_hierarchy_args[] = { VT_STR, 0 };
+
+static const ext_idcfunc_t idc_funcs[] = {
+    { "VTableExplorer_Scan",      idc_scan,      idc_scan_args,      nullptr, 0, EXTFUN_BASE },
+    { "VTableExplorer_Entries",   idc_entries,   idc_entries_args,   nullptr, 0, EXTFUN_BASE },
+    { "VTableExplorer_Compare",   idc_compare,   idc_compare_args,   nullptr, 0, EXTFUN_BASE },
+    { "VTableExplorer_Hierarchy", idc_hierarchy, idc_hierarchy_args, nullptr, 0, EXTFUN_BASE },
+};
+
+inline void register_vtable_idc_functions() {
+    for (const auto &f : idc_funcs)
+        add_idc_func(f);
+}
+
+inline void unregister_vtable_idc_functions() {
+    for (const auto &f : idc_funcs)
+        del_idc_func(f.name);
+}
+
+} // namespace vtable_idc

--- a/src/vtable_json.h
+++ b/src/vtable_json.h
@@ -1,0 +1,236 @@
+#pragma once
+#include <string>
+#include <vector>
+#include <ida.hpp>
+#include "vtable_detector.h"
+#include "smart_annotator.h"
+#include "vtable_comparison.h"
+#include "vtable_utils.h"
+
+namespace vtable_json {
+
+// Minimal JSON helpers — no external dependencies
+
+inline std::string escape_json(const std::string &s) {
+    std::string out;
+    out.reserve(s.size() + 8);
+    for (char c : s) {
+        switch (c) {
+            case '"':  out += "\\\""; break;
+            case '\\': out += "\\\\"; break;
+            case '\b': out += "\\b";  break;
+            case '\f': out += "\\f";  break;
+            case '\n': out += "\\n";  break;
+            case '\r': out += "\\r";  break;
+            case '\t': out += "\\t";  break;
+            default:   out += c;      break;
+        }
+    }
+    return out;
+}
+
+inline std::string addr_str(ea_t addr) {
+    if (addr == BADADDR) return "null";
+    char buf[32];
+    qsnprintf(buf, sizeof(buf), "\"0x%llX\"", (unsigned long long)addr);
+    return buf;
+}
+
+inline std::string json_str(const std::string &s) {
+    return "\"" + escape_json(s) + "\"";
+}
+
+inline std::string json_bool(bool v) {
+    return v ? "true" : "false";
+}
+
+inline std::string json_int(int v) {
+    char buf[16];
+    qsnprintf(buf, sizeof(buf), "%d", v);
+    return buf;
+}
+
+inline std::string string_array(const std::vector<std::string> &arr) {
+    std::string out = "[";
+    for (size_t i = 0; i < arr.size(); ++i) {
+        if (i > 0) out += ",";
+        out += json_str(arr[i]);
+    }
+    out += "]";
+    return out;
+}
+
+// --- Serialization functions ---
+
+inline std::string vtables_to_json(const std::vector<VTableInfo> &vtables) {
+    std::string out = "[";
+    bool first = true;
+    for (const auto &vt : vtables) {
+        if (!first) out += ",";
+        first = false;
+        out += "{";
+        out += "\"address\":" + addr_str(vt.address);
+        out += ",\"class_name\":" + json_str(vt.class_name);
+        out += ",\"display_name\":" + json_str(vt.display_name);
+        out += ",\"func_count\":" + json_int(vt.func_count);
+        out += ",\"pure_virtual_count\":" + json_int(vt.pure_virtual_count);
+        out += ",\"is_abstract\":" + json_bool(vt.pure_virtual_count > 0);
+        out += ",\"base_classes\":" + string_array(vt.base_classes);
+        out += ",\"derived_classes\":" + string_array(vt.derived_classes);
+        out += ",\"derived_count\":" + json_int(vt.derived_count);
+        out += ",\"has_multiple_inheritance\":" + json_bool(vt.has_multiple_inheritance);
+        out += ",\"has_virtual_inheritance\":" + json_bool(vt.has_virtual_inheritance);
+        out += ",\"is_intermediate\":" + json_bool(vt.is_intermediate);
+        out += ",\"is_windows\":" + json_bool(vt.is_windows);
+        out += "}";
+    }
+    out += "]";
+    return out;
+}
+
+inline std::string vtable_entries_to_json(
+    ea_t vtable_addr,
+    const std::string &class_name,
+    const std::vector<smart_annotator::VTableEntry> &entries)
+{
+    std::string out = "{";
+    out += "\"address\":" + addr_str(vtable_addr);
+    out += ",\"class_name\":" + json_str(class_name);
+    out += ",\"entries\":[";
+    bool first = true;
+    for (const auto &e : entries) {
+        if (!first) out += ",";
+        first = false;
+
+        // Get function name
+        qstring name;
+        std::string func_name;
+        if (get_name(&name, e.func_ptr) && name.length() > 0)
+            func_name = std::string(name.c_str());
+
+        out += "{";
+        out += "\"index\":" + json_int(e.index);
+        out += ",\"slot_addr\":" + addr_str(e.entry_addr);
+        out += ",\"func_addr\":" + addr_str(e.func_ptr);
+        out += ",\"func_name\":" + json_str(func_name);
+        out += ",\"is_pure_virtual\":" + json_bool(e.is_pure_virtual);
+        out += "}";
+    }
+    out += "]}";
+    return out;
+}
+
+inline const char *override_status_str(vtable_comparison::OverrideStatus s) {
+    switch (s) {
+        case vtable_comparison::OverrideStatus::INHERITED:    return "inherited";
+        case vtable_comparison::OverrideStatus::OVERRIDDEN:   return "overridden";
+        case vtable_comparison::OverrideStatus::NEW_VIRTUAL:  return "new_virtual";
+        case vtable_comparison::OverrideStatus::PURE_TO_IMPL: return "pure_to_impl";
+        case vtable_comparison::OverrideStatus::IMPL_TO_PURE: return "impl_to_pure";
+        default: return "unknown";
+    }
+}
+
+inline std::string vtable_comparison_to_json(
+    const vtable_comparison::VTableComparison &cmp)
+{
+    std::string out = "{";
+    out += "\"derived_class\":" + json_str(cmp.derived_class);
+    out += ",\"base_class\":" + json_str(cmp.base_class);
+    out += ",\"derived_vtable\":" + addr_str(cmp.derived_vtable);
+    out += ",\"base_vtable\":" + addr_str(cmp.base_vtable);
+    out += ",\"inherited_count\":" + json_int(cmp.inherited_count);
+    out += ",\"overridden_count\":" + json_int(cmp.overridden_count);
+    out += ",\"new_virtual_count\":" + json_int(cmp.new_virtual_count);
+    out += ",\"entries\":[";
+    bool first = true;
+    for (const auto &e : cmp.entries) {
+        if (!first) out += ",";
+        first = false;
+        out += "{";
+        out += "\"index\":" + json_int(e.index);
+        out += ",\"derived_func_addr\":" + addr_str(e.derived_func_ptr);
+        out += ",\"derived_func_name\":" + json_str(e.derived_func_name);
+        out += ",\"base_func_addr\":" + addr_str(e.base_func_ptr);
+        out += ",\"base_func_name\":" + json_str(e.base_func_name);
+        out += ",\"status\":\"" + std::string(override_status_str(e.status)) + "\"";
+        out += ",\"is_pure_virtual_base\":" + json_bool(e.is_pure_virtual_base);
+        out += ",\"is_pure_virtual_derived\":" + json_bool(e.is_pure_virtual_derived);
+        out += "}";
+    }
+    out += "]}";
+    return out;
+}
+
+inline std::string vtable_hierarchy_to_json(
+    const std::string &root_class,
+    const std::vector<VTableInfo> &vtables)
+{
+    // Find the root vtable
+    const VTableInfo *root = nullptr;
+    for (const auto &vt : vtables) {
+        if (vt.class_name == root_class) {
+            root = &vt;
+            break;
+        }
+    }
+
+    if (!root)
+        return "{\"error\":\"class not found\",\"class_name\":" + json_str(root_class) + "}";
+
+    // Build class->vtable map
+    std::map<std::string, const VTableInfo *> vtable_map;
+    for (const auto &vt : vtables)
+        vtable_map[vt.class_name] = &vt;
+
+    // Collect ancestors
+    std::vector<std::string> ancestors;
+    {
+        std::set<std::string> seen;
+        std::function<void(const std::string &)> walk_up;
+        walk_up = [&](const std::string &cls) {
+            auto it = vtable_map.find(cls);
+            if (it == vtable_map.end()) return;
+            for (const auto &base : it->second->base_classes) {
+                if (seen.insert(base).second) {
+                    ancestors.push_back(base);
+                    walk_up(base);
+                }
+            }
+        };
+        walk_up(root_class);
+    }
+
+    // Collect descendants
+    std::vector<std::string> descendants;
+    {
+        std::set<std::string> seen;
+        std::function<void(const std::string &)> walk_down;
+        walk_down = [&](const std::string &cls) {
+            for (const auto &vt : vtables) {
+                for (const auto &base : vt.base_classes) {
+                    if (base == cls && seen.insert(vt.class_name).second) {
+                        descendants.push_back(vt.class_name);
+                        walk_down(vt.class_name);
+                        break;
+                    }
+                }
+            }
+        };
+        walk_down(root_class);
+    }
+
+    std::string out = "{";
+    out += "\"class_name\":" + json_str(root->class_name);
+    out += ",\"address\":" + addr_str(root->address);
+    out += ",\"func_count\":" + json_int(root->func_count);
+    out += ",\"is_abstract\":" + json_bool(root->pure_virtual_count > 0);
+    out += ",\"ancestors\":" + string_array(ancestors);
+    out += ",\"descendants\":" + string_array(descendants);
+    out += ",\"base_classes\":" + string_array(root->base_classes);
+    out += ",\"derived_classes\":" + string_array(root->derived_classes);
+    out += "}";
+    return out;
+}
+
+} // namespace vtable_json


### PR DESCRIPTION
Closes #5

## Summary

Adds programmatic access to VTableExplorer's analysis data by registering 4 IDC functions that return JSON strings. Callable from IDAPython via `idc.eval_idc()` — zero-copy, in-process, no file I/O.

| IDC Function | Returns |
|---|---|
| `VTableExplorer_Scan()` | All vtables with class names, function counts, inheritance info |
| `VTableExplorer_Entries(addr)` | Per-slot entries for a specific vtable |
| `VTableExplorer_Compare(derived, base)` | Inherited/overridden/new virtual comparison |
| `VTableExplorer_Hierarchy(class_name)` | Ancestors and descendants for a class |

## Changes

- **`src/vtable_json.h`** (new): Minimal JSON serializer, no external dependencies
- **`src/vtable_idc.h`** (new): IDC function registration via `add_idc_func()`/`del_idc_func()`
- **`src/main.cpp`** (modified): Wire up registration in `init()` / cleanup in destructor
- **`CMakeLists.txt`** (new): Native Windows MSVC build support
- **`scripts/vtable_explorer.py`** (new): IDAPython convenience wrapper
- **`scripts/test_json_export.py`** (new): Test script validating all 4 functions + error handling

## Tested on

- IDA Pro 9.3, Windows, MSVC 19.43
- ARM32 ELF binary with GCC/Itanium vtables (43 vtables detected)
- All 4 IDC functions return valid JSON
- Error cases return proper error JSON
- Existing GUI functionality unchanged

## Example

```python
import idc, json

# List all vtables
vtables = json.loads(idc.eval_idc("VTableExplorer_Scan()"))
for vt in vtables:
    print(f"{vt['class_name']} @ {vt['address']} ({vt['func_count']} funcs)")

# Get entries for a specific vtable
entries = json.loads(idc.eval_idc(f"VTableExplorer_Entries({vtables[0]['address']})"))
for e in entries['entries']:
    print(f"  [{e['index']}] {e['func_name']}")
```